### PR TITLE
fix: batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,61 @@
 # SQL Datastore
 
+[![CircleCI](https://circleci.com/gh/ipfs/go-ds-sql.svg?style=shield)](https://circleci.com/gh/ipfs/go-ds-sql)
+[![Coverage](https://codecov.io/gh/ipfs/go-ds-sql/branch/master/graph/badge.svg)](https://codecov.io/gh/ipfs/go-ds-sql)
+[![Standard README](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg)](https://github.com/RichardLitt/standard-readme)
+[![GoDoc](http://img.shields.io/badge/godoc-reference-5272B4.svg)](https://godoc.org/github.com/ipfs/go-ds-sql)
+[![golang version](https://img.shields.io/badge/golang-%3E%3D1.14.0-orange.svg)](https://golang.org/)
+[![Go Report Card](https://goreportcard.com/badge/github.com/ipfs/go-ds-sql)](https://goreportcard.com/report/github.com/ipfs/go-ds-sql)
+
 An implementation of [the datastore interface](https://github.com/ipfs/go-datastore)
 that can be backed by any sql database.
 
+## Install
+
+```sh
+go get github.com/ipfs/go-ds-sql
+```
+
 ## Usage
+
+Ensure a database is created and a table exists with `key` and `data` columns. For example, in PostgreSQL you can create a table with the following structure (replacing `table_name` with the name of the table the datastore will use - by default this is `blocks`):
+
+```sql
+CREATE TABLE IF NOT EXISTS table_name (key TEXT NOT NULL UNIQUE, data BYTEA)
+```
+
+It's recommended to create an index on the `key` column that is optimised for prefix scans. For example, in PostgreSQL you can create a `text_pattern_ops` index on the table:
+
+```sql
+CREATE INDEX IF NOT EXISTS table_name_key_text_pattern_ops_idx ON table_name (key text_pattern_ops)
+```
+
+Import and use in your application:
 
 ```go
 import (
 	"database/sql"
 	"github.com/ipfs/go-ds-sql"
+	pg "github.com/ipfs/go-ds-sql/postgres"
 )
 
 mydb, _ := sql.Open("yourdb", "yourdbparameters")
 
-ds := sqlds.NewDatastore(mydb)
+// Implement the Queries interface for your SQL impl.
+// ...or use the provided PostgreSQL queries
+queries := pg.NewQueries("blocks")
+
+ds := sqlds.NewDatastore(mydb, queries)
 ```
 
+## API
+
+[GoDoc Reference](https://godoc.org/github.com/ipfs/go-ds-sql)
+
+## Contribute
+
+Feel free to dive in! [Open an issue](https://github.com/ipfs/go-ds-sql/issues/new) or submit PRs.
+
 ## License
-MIT
+
+[MIT](LICENSE)

--- a/batching.go
+++ b/batching.go
@@ -1,0 +1,54 @@
+package sqlds
+
+import (
+	ds "github.com/ipfs/go-datastore"
+)
+
+type op struct {
+	delete bool
+	value  []byte
+}
+
+type batch struct {
+	ds  *Datastore
+	ops map[ds.Key]op
+}
+
+// Batch creates a set of deferred updates to the database.
+// Since SQL does not support a true batch of updates,
+// operations are buffered and then executed sequentially
+// when Commit is called.
+func (d *Datastore) Batch() (ds.Batch, error) {
+	return &batch{
+		ds:  d,
+		ops: make(map[ds.Key]op),
+	}, nil
+}
+
+func (bt *batch) Put(key ds.Key, val []byte) error {
+	bt.ops[key] = op{value: val}
+	return nil
+}
+
+func (bt *batch) Delete(key ds.Key) error {
+	bt.ops[key] = op{delete: true}
+	return nil
+}
+
+func (bt *batch) Commit() error {
+	var err error
+	for k, op := range bt.ops {
+		if op.delete {
+			err = bt.ds.Delete(k)
+		} else {
+			err = bt.ds.Put(k, op.value)
+		}
+		if err != nil {
+			break
+		}
+	}
+
+	return err
+}
+
+var _ ds.Batching = (*Datastore)(nil)

--- a/dstore.go
+++ b/dstore.go
@@ -8,6 +8,7 @@ import (
 	dsq "github.com/ipfs/go-datastore/query"
 )
 
+// Queries generates SQL queries for datastore operations.
 type Queries interface {
 	Delete() string
 	Exists() string
@@ -20,116 +21,33 @@ type Queries interface {
 	GetSize() string
 }
 
+// Datastore is a SQL backed datastore.
 type Datastore struct {
 	db      *sql.DB
 	queries Queries
 }
 
-// NewDatastore returns a new datastore
+// NewDatastore returns a new SQL datastore.
 func NewDatastore(db *sql.DB, queries Queries) *Datastore {
 	return &Datastore{db: db, queries: queries}
 }
 
-type batch struct {
-	db      *sql.DB
-	queries Queries
-	txn     *sql.Tx
-}
-
-func (b *batch) GetTransaction() (*sql.Tx, error) {
-	if b.txn != nil {
-		return b.txn, nil
-	}
-
-	newTransaction, err := b.db.Begin()
-	if err != nil {
-		if newTransaction != nil {
-			// nothing we can do about this error.
-			_ = newTransaction.Rollback()
-		}
-
-		return nil, err
-	}
-
-	b.txn = newTransaction
-	return newTransaction, nil
-}
-
-func (b *batch) Put(key ds.Key, val []byte) error {
-	txn, err := b.GetTransaction()
-	if err != nil {
-		return err
-	}
-
-	_, err = txn.Exec(b.queries.Put(), key.String(), val)
-	if err != nil {
-		_ = b.txn.Rollback()
-		return err
-	}
-
-	return nil
-}
-
-func (b *batch) Delete(key ds.Key) error {
-	txn, err := b.GetTransaction()
-	if err != nil {
-		return err
-	}
-
-	_, err = txn.Exec(b.queries.Delete(), key.String())
-	if err != nil {
-		_ = b.txn.Rollback()
-		return err
-	}
-
-	return err
-}
-
-func (b *batch) Commit() error {
-	if b.txn == nil {
-		return nil // no Put or Delete calls were made, nothing to do
-	}
-	err := b.txn.Commit()
-	if err != nil {
-		_ = b.txn.Rollback()
-		return err
-	}
-
-	return nil
-}
-
-func (d *Datastore) Batch() (ds.Batch, error) {
-	batch := &batch{
-		db:      d.db,
-		queries: d.queries,
-		txn:     nil,
-	}
-
-	return batch, nil
-}
-
+// Close closes the underying SQL database.
 func (d *Datastore) Close() error {
 	return d.db.Close()
 }
 
+// Delete removes a row from the SQL database by the given key.
 func (d *Datastore) Delete(key ds.Key) error {
-	result, err := d.db.Exec(d.queries.Delete(), key.String())
+	_, err := d.db.Exec(d.queries.Delete(), key.String())
 	if err != nil {
 		return err
-	}
-
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return err
-	}
-
-	if rows == 0 {
-		return ds.ErrNotFound
 	}
 
 	return nil
 }
 
+// Get retrieves a value from the SQL database by the given key.
 func (d *Datastore) Get(key ds.Key) (value []byte, err error) {
 	row := d.db.QueryRow(d.queries.Get(), key.String())
 	var out []byte
@@ -144,6 +62,7 @@ func (d *Datastore) Get(key ds.Key) (value []byte, err error) {
 	}
 }
 
+// Has determines if a value for the given key exists in the SQL database.
 func (d *Datastore) Has(key ds.Key) (exists bool, err error) {
 	row := d.db.QueryRow(d.queries.Exists(), key.String())
 
@@ -157,6 +76,7 @@ func (d *Datastore) Has(key ds.Key) (exists bool, err error) {
 	}
 }
 
+// Put "upserts" a row into the SQL database.
 func (d *Datastore) Put(key ds.Key, value []byte) error {
 	_, err := d.db.Exec(d.queries.Put(), key.String(), value)
 	if err != nil {
@@ -166,8 +86,9 @@ func (d *Datastore) Put(key ds.Key, value []byte) error {
 	return nil
 }
 
+// Query returns multiple rows from the SQL database based on the passed query parameters.
 func (d *Datastore) Query(q dsq.Query) (dsq.Results, error) {
-	raw, err := d.RawQuery(q)
+	raw, err := d.rawQuery(q)
 	if err != nil {
 		return nil, err
 	}
@@ -191,11 +112,11 @@ func (d *Datastore) Query(q dsq.Query) (dsq.Results, error) {
 	return raw, nil
 }
 
-func (d *Datastore) RawQuery(q dsq.Query) (dsq.Results, error) {
+func (d *Datastore) rawQuery(q dsq.Query) (dsq.Results, error) {
 	var rows *sql.Rows
 	var err error
 
-	rows, err = QueryWithParams(d, q)
+	rows, err = queryWithParams(d, q)
 	if err != nil {
 		return nil, err
 	}
@@ -233,10 +154,12 @@ func (d *Datastore) RawQuery(q dsq.Query) (dsq.Results, error) {
 	return dsq.ResultsFromIterator(q, it), nil
 }
 
+// Sync is noop for SQL databases.
 func (d *Datastore) Sync(key ds.Key) error {
 	return nil
 }
 
+// GetSize determines the size in bytes of the value for a given key.
 func (d *Datastore) GetSize(key ds.Key) (int, error) {
 	row := d.db.QueryRow(d.queries.GetSize(), key.String())
 	var size int
@@ -251,8 +174,8 @@ func (d *Datastore) GetSize(key ds.Key) (int, error) {
 	}
 }
 
-// QueryWithParams applies prefix, limit, and offset params in pg query
-func QueryWithParams(d *Datastore, q dsq.Query) (*sql.Rows, error) {
+// queryWithParams applies prefix, limit, and offset params in pg query
+func queryWithParams(d *Datastore, q dsq.Query) (*sql.Rows, error) {
 	var qNew = d.queries.Query()
 
 	if q.Prefix != "" {

--- a/dstore.go
+++ b/dstore.go
@@ -2,7 +2,6 @@ package sqlds
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 
 	ds "github.com/ipfs/go-datastore"
@@ -59,7 +58,6 @@ func (b *batch) GetTransaction() (*sql.Tx, error) {
 func (b *batch) Put(key ds.Key, val []byte) error {
 	txn, err := b.GetTransaction()
 	if err != nil {
-		_ = b.txn.Rollback()
 		return err
 	}
 
@@ -75,7 +73,6 @@ func (b *batch) Put(key ds.Key, val []byte) error {
 func (b *batch) Delete(key ds.Key) error {
 	txn, err := b.GetTransaction()
 	if err != nil {
-		_ = b.txn.Rollback()
 		return err
 	}
 
@@ -90,9 +87,9 @@ func (b *batch) Delete(key ds.Key) error {
 
 func (b *batch) Commit() error {
 	if b.txn == nil {
-		return errors.New("no transaction started, cannot commit")
+		return nil // no Put or Delete calls were made, nothing to do
 	}
-	var err = b.txn.Commit()
+	err := b.txn.Commit()
 	if err != nil {
 		_ = b.txn.Rollback()
 		return err

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -11,12 +11,12 @@ import (
 
 // Options are the postgres datastore options, reexported here for convenience.
 type Options struct {
-	Host      string
-	Port      string
-	User      string
-	Password  string
-	Database  string
-	TableName string
+	Host     string
+	Port     string
+	User     string
+	Password string
+	Database string
+	Table    string
 }
 
 // Queries are the postgres queries for a given table.
@@ -102,7 +102,7 @@ func (opts *Options) Create() (*sqlds.Datastore, error) {
 		return nil, err
 	}
 
-	return sqlds.NewDatastore(db, NewQueries(opts.TableName)), nil
+	return sqlds.NewDatastore(db, NewQueries(opts.Table)), nil
 }
 
 func (opts *Options) setDefaults() {
@@ -122,7 +122,7 @@ func (opts *Options) setDefaults() {
 		opts.Database = "datastore"
 	}
 
-	if opts.TableName == "" {
-		opts.TableName = "blocks"
+	if opts.Table == "" {
+		opts.Table = "blocks"
 	}
 }

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -4,57 +4,69 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/ipfs/go-ds-sql"
+	sqlds "github.com/ipfs/go-ds-sql"
 
 	_ "github.com/lib/pq" //postgres driver
 )
 
 // Options are the postgres datastore options, reexported here for convenience.
 type Options struct {
-	Host     string
-	Port     string
-	User     string
-	Password string
-	Database string
+	Host      string
+	Port      string
+	User      string
+	Password  string
+	Database  string
+	TableName string
 }
 
+// Queries are the postgres queries for a given table.
 type Queries struct {
+	TableName string
 }
 
-func (Queries) Delete() string {
-	return `DELETE FROM blocks WHERE key = $1`
+// Delete returns the postgres query for deleting a row.
+func (q Queries) Delete() string {
+	return fmt.Sprintf("DELETE FROM %s WHERE key = $1", q.TableName)
 }
 
-func (Queries) Exists() string {
-	return `SELECT exists(SELECT 1 FROM blocks WHERE key=$1)`
+// Exists returns the postgres query for determining if a row exists.
+func (q Queries) Exists() string {
+	return fmt.Sprintf("SELECT exists(SELECT 1 FROM %s WHERE key=$1)", q.TableName)
 }
 
-func (Queries) Get() string {
-	return `SELECT data FROM blocks WHERE key = $1`
+// Get returns the postgres query for getting a row.
+func (q Queries) Get() string {
+	return fmt.Sprintf("SELECT data FROM %s WHERE key = $1", q.TableName)
 }
 
-func (Queries) Put() string {
-	return `INSERT INTO blocks (key, data) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET data = $2`
+// Put returns the postgres query for putting a row.
+func (q Queries) Put() string {
+	return fmt.Sprintf("INSERT INTO %s (key, data) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET data = $2", q.TableName)
 }
 
-func (Queries) Query() string {
-	return `SELECT key, data FROM blocks`
+// Query returns the postgres query for getting multiple rows.
+func (q Queries) Query() string {
+	return fmt.Sprintf("SELECT key, data FROM %s", q.TableName)
 }
 
+// Prefix returns the postgres query fragment for getting a rows with a key prefix.
 func (Queries) Prefix() string {
 	return ` WHERE key LIKE '%s%%' ORDER BY key`
 }
 
+// Limit returns the postgres query fragment for limiting results.
 func (Queries) Limit() string {
 	return ` LIMIT %d`
 }
 
+// Offset returns the postgres query fragment for returning rows from a given offset.
 func (Queries) Offset() string {
 	return ` OFFSET %d`
 }
 
-func (Queries) GetSize() string {
-	return `SELECT octet_length(data) FROM blocks WHERE key = $1`
+// GetSize returns the postgres query for determining the size of a value.
+func (q Queries) GetSize() string {
+	return fmt.Sprintf("SELECT octet_length(data) FROM %s WHERE key = $1", q.TableName)
 }
 
 // Create returns a datastore connected to postgres
@@ -67,7 +79,7 @@ func (opts *Options) Create() (*sqlds.Datastore, error) {
 		return nil, err
 	}
 
-	return sqlds.NewDatastore(db, Queries{}), nil
+	return sqlds.NewDatastore(db, Queries{TableName: opts.TableName}), nil
 }
 
 func (opts *Options) setDefaults() {
@@ -85,5 +97,9 @@ func (opts *Options) setDefaults() {
 
 	if opts.Database == "" {
 		opts.Database = "datastore"
+	}
+
+	if opts.TableName == "" {
+		opts.TableName = "blocks"
 	}
 }

--- a/postgres/postgres.go
+++ b/postgres/postgres.go
@@ -21,52 +21,75 @@ type Options struct {
 
 // Queries are the postgres queries for a given table.
 type Queries struct {
-	TableName string
+	deleteQuery  string
+	existsQuery  string
+	getQuery     string
+	putQuery     string
+	queryQuery   string
+	prefixQuery  string
+	limitQuery   string
+	offsetQuery  string
+	getSizeQuery string
+}
+
+// NewQueries creates a new PostgreSQL set of queries for the passed table
+func NewQueries(tbl string) Queries {
+	return Queries{
+		deleteQuery:  fmt.Sprintf("DELETE FROM %s WHERE key = $1", tbl),
+		existsQuery:  fmt.Sprintf("SELECT exists(SELECT 1 FROM %s WHERE key=$1)", tbl),
+		getQuery:     fmt.Sprintf("SELECT data FROM %s WHERE key = $1", tbl),
+		putQuery:     fmt.Sprintf("INSERT INTO %s (key, data) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET data = $2", tbl),
+		queryQuery:   fmt.Sprintf("SELECT key, data FROM %s", tbl),
+		prefixQuery:  ` WHERE key LIKE '%s%%' ORDER BY key`,
+		limitQuery:   ` LIMIT %d`,
+		offsetQuery:  ` OFFSET %d`,
+		getSizeQuery: fmt.Sprintf("SELECT octet_length(data) FROM %s WHERE key = $1", tbl),
+	}
 }
 
 // Delete returns the postgres query for deleting a row.
 func (q Queries) Delete() string {
-	return fmt.Sprintf("DELETE FROM %s WHERE key = $1", q.TableName)
+	return q.deleteQuery
 }
 
 // Exists returns the postgres query for determining if a row exists.
 func (q Queries) Exists() string {
-	return fmt.Sprintf("SELECT exists(SELECT 1 FROM %s WHERE key=$1)", q.TableName)
+	return q.existsQuery
 }
 
 // Get returns the postgres query for getting a row.
 func (q Queries) Get() string {
-	return fmt.Sprintf("SELECT data FROM %s WHERE key = $1", q.TableName)
+	return q.getQuery
 }
 
 // Put returns the postgres query for putting a row.
 func (q Queries) Put() string {
-	return fmt.Sprintf("INSERT INTO %s (key, data) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET data = $2", q.TableName)
+	return q.putQuery
 }
 
 // Query returns the postgres query for getting multiple rows.
 func (q Queries) Query() string {
-	return fmt.Sprintf("SELECT key, data FROM %s", q.TableName)
+	return q.queryQuery
 }
 
 // Prefix returns the postgres query fragment for getting a rows with a key prefix.
-func (Queries) Prefix() string {
-	return ` WHERE key LIKE '%s%%' ORDER BY key`
+func (q Queries) Prefix() string {
+	return q.prefixQuery
 }
 
 // Limit returns the postgres query fragment for limiting results.
-func (Queries) Limit() string {
-	return ` LIMIT %d`
+func (q Queries) Limit() string {
+	return q.limitQuery
 }
 
 // Offset returns the postgres query fragment for returning rows from a given offset.
-func (Queries) Offset() string {
-	return ` OFFSET %d`
+func (q Queries) Offset() string {
+	return q.offsetQuery
 }
 
 // GetSize returns the postgres query for determining the size of a value.
 func (q Queries) GetSize() string {
-	return fmt.Sprintf("SELECT octet_length(data) FROM %s WHERE key = $1", q.TableName)
+	return q.getSizeQuery
 }
 
 // Create returns a datastore connected to postgres
@@ -79,7 +102,7 @@ func (opts *Options) Create() (*sqlds.Datastore, error) {
 		return nil, err
 	}
 
-	return sqlds.NewDatastore(db, Queries{TableName: opts.TableName}), nil
+	return sqlds.NewDatastore(db, NewQueries(opts.TableName)), nil
 }
 
 func (opts *Options) setDefaults() {

--- a/txn.go
+++ b/txn.go
@@ -1,0 +1,122 @@
+package sqlds
+
+import (
+	"database/sql"
+	"fmt"
+
+	datastore "github.com/ipfs/go-datastore"
+	ds "github.com/ipfs/go-datastore"
+	dsq "github.com/ipfs/go-datastore/query"
+)
+
+// ErrNotImplemented is returned when the SQL datastore does not yet implement the function call.
+var ErrNotImplemented = fmt.Errorf("not implemented")
+
+type txn struct {
+	db      *sql.DB
+	queries Queries
+	txn     *sql.Tx
+}
+
+// NewTransaction creates a new database transaction, note the readOnly parameter is ignored by this implementation.
+func (ds *Datastore) NewTransaction(_ bool) (datastore.Txn, error) {
+	sqlTxn, err := ds.db.Begin()
+	if err != nil {
+		if sqlTxn != nil {
+			// nothing we can do about this error.
+			_ = sqlTxn.Rollback()
+		}
+
+		return nil, err
+	}
+
+	return &txn{
+		db:      ds.db,
+		queries: ds.queries,
+		txn:     sqlTxn,
+	}, nil
+}
+
+func (t *txn) Get(key ds.Key) ([]byte, error) {
+	row := t.txn.QueryRow(t.queries.Get(), key.String())
+	var out []byte
+
+	switch err := row.Scan(&out); err {
+	case sql.ErrNoRows:
+		return nil, ds.ErrNotFound
+	case nil:
+		return out, nil
+	default:
+		return nil, err
+	}
+}
+
+func (t *txn) Has(key ds.Key) (bool, error) {
+	row := t.txn.QueryRow(t.queries.Exists(), key.String())
+	var exists bool
+
+	switch err := row.Scan(&exists); err {
+	case sql.ErrNoRows:
+		return exists, nil
+	case nil:
+		return exists, nil
+	default:
+		return exists, err
+	}
+}
+
+func (t *txn) GetSize(key ds.Key) (int, error) {
+	row := t.txn.QueryRow(t.queries.GetSize(), key.String())
+	var size int
+
+	switch err := row.Scan(&size); err {
+	case sql.ErrNoRows:
+		return -1, ds.ErrNotFound
+	case nil:
+		return size, nil
+	default:
+		return 0, err
+	}
+}
+
+func (t *txn) Query(q dsq.Query) (dsq.Results, error) {
+	return nil, ErrNotImplemented
+}
+
+// Put adds a value to the datastore identified by the given key.
+func (t *txn) Put(key ds.Key, val []byte) error {
+	_, err := t.txn.Exec(t.queries.Put(), key.String(), val)
+	if err != nil {
+		_ = t.txn.Rollback()
+		return err
+	}
+	return nil
+}
+
+// Delete removes a value from the datastore that matches the given key.
+func (t *txn) Delete(key ds.Key) error {
+	_, err := t.txn.Exec(t.queries.Delete(), key.String())
+	if err != nil {
+		_ = t.txn.Rollback()
+		return err
+	}
+	return nil
+}
+
+// Commit finalizes a transaction.
+func (t *txn) Commit() error {
+	err := t.txn.Commit()
+	if err != nil {
+		_ = t.txn.Rollback()
+		return err
+	}
+	return nil
+}
+
+// Discard throws away changes recorded in a transaction without committing
+// them to the underlying Datastore.
+func (t *txn) Discard() {
+	_ = t.txn.Rollback()
+}
+
+var _ ds.TxnDatastore = (*Datastore)(nil)


### PR DESCRIPTION
Batching is currently implemented as a SQL transaction, but this is problematic when it's used with [autobatch](https://github.com/ipfs/go-datastore/tree/master/autobatch) since we cannot control the content or order of statements in each transaction.

It leads to deadlocks like:

![Screenshot 2020-04-16 at 16 49 11](https://user-images.githubusercontent.com/152863/80111553-ee124a80-8577-11ea-9e2c-740d8d1b2106.png)

For example, Tx1 and Tx2 want to update keys A and B:

1. Tx1 locks key A to update
2. Meanwhile Tx2 locks key B to update
3. Tx1 then attempts to lock B, but cannot because Tx2 already has a lock on B.
4. Tx2 then tries to lock A, but cannot because Tx1 already has a lock on A.
5. Deadlock

> Batching datastores support deferred, grouped updates to the database. `Batch`es do NOT have transactional semantics: updates to the underlying datastore are not guaranteed to occur in the same iota of time.
> https://godoc.org/github.com/ipfs/go-datastore#Batching 

SQL does not support batching, other than stringing SQL statements together. We _could_ do something like this but it's a bit messy and complicated, and would have caveats like maximum query length for example.

This PR just does the simple thing that [`basicBatch`](https://github.com/ipfs/go-datastore/blob/master/batch.go) does and fires off the SQL commands one by one when `Commit` is called. It's not an atomic operation like it should be but it won't cause deadlocks when used with autobatch.

The existing transaction based batch code has been modified to satisfy the `Txn` interface from `go-datastore` i.e. you can now call `sqlds.NewTransaction()`

Side note: I'm not sure if this is worth looking into but I noticed that the [badger datastore](https://github.com/ipfs/go-ds-badger) implements batching as a transaction also so might also be deadlocking when it's used with autobatch.

Note: this PR supersedes and closes #15