### PR TITLE
set up postgresql for go test

### DIFF
--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -22,5 +22,5 @@ runs:
     - if: ${{ runner.os == 'macOS' }}
       run: createuser -s postgres
       shell: bash
-    - run: echo "GOFLAGS=$GOFLAGS -timeout=20m" >> $GITHUB_ENV
+    - run: echo "GOFLAGS=$GOFLAGS -timeout=30m" >> $GITHUB_ENV
       shell: bash

--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -1,0 +1,24 @@
+name: postgresql
+description: Start PostgreSQL
+
+runs:
+  using: "composite"
+  steps:
+    - if: ${{ runner.os == 'Linux' }}
+      run: |
+        PGCONF="$(ls /etc/postgresql/*/main/pg_hba.conf)"
+        sudo sed -i.bak -E "s/peer|scram-sha-256/trust/g" "$PGCONF"
+        sudo service postgresql start
+      shell: bash
+    - if: ${{ runner.os == 'Windows' }}
+      run: echo "$PGBIN" >> $GITHUB_PATH
+      shell: bash
+    - if: ${{ runner.os == 'macOS' }}
+      run: echo "PGDATA=/usr/local/var/postgres" >> $GITHUB_ENV
+      shell: bash
+    - if: ${{ runner.os == 'Windows' || runner.os == 'macOS' }}
+      run: pg_ctl -D "$PGDATA" -l "$PGDATA/server.log" start
+      shell: bash
+    - if: ${{ runner.os == 'macOS' }}
+      run: createuser -s postgres
+      shell: bash

--- a/.github/actions/go-test-setup/action.yml
+++ b/.github/actions/go-test-setup/action.yml
@@ -1,5 +1,5 @@
-name: postgresql
-description: Start PostgreSQL
+name: postgresql-and-timeout
+description: Start PostgreSQL and increase timeout
 
 runs:
   using: "composite"
@@ -21,4 +21,6 @@ runs:
       shell: bash
     - if: ${{ runner.os == 'macOS' }}
       run: createuser -s postgres
+      shell: bash
+    - run: echo "GOFLAGS=$GOFLAGS -timeout=20m" >> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION
This PR adds postgresql setup for `go-test` workflow. It also increases the go test timeout to 30m because the tests on windows take ~20m(https://github.com/ipfs/go-ds-sql/runs/4509480385?check_suite_focus=true).

This will enable merging unified CI: https://github.com/ipfs/go-ds-sql/pull/23