### PR TITLE
update error checks to use errors.Is

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![CircleCI](https://circleci.com/gh/ipfs/go-ds-sql.svg?style=shield)](https://circleci.com/gh/ipfs/go-ds-sql)
 [![Coverage](https://codecov.io/gh/ipfs/go-ds-sql/branch/master/graph/badge.svg)](https://codecov.io/gh/ipfs/go-ds-sql)
-[![Standard README](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg)](https://github.com/RichardLitt/standard-readme)
 [![GoDoc](http://img.shields.io/badge/godoc-reference-5272B4.svg)](https://godoc.org/github.com/ipfs/go-ds-sql)
 [![golang version](https://img.shields.io/badge/golang-%3E%3D1.14.0-orange.svg)](https://golang.org/)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ipfs/go-ds-sql)](https://goreportcard.com/report/github.com/ipfs/go-ds-sql)

--- a/ds_test.go
+++ b/ds_test.go
@@ -2,11 +2,11 @@ package sqlds
 
 import (
 	"bytes"
-	"context"
 	"crypto/rand"
 	"database/sql"
+	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -120,21 +120,21 @@ func newDS(t *testing.T) (*Datastore, func()) {
 }
 
 func addTestCases(t *testing.T, d *Datastore, testcases map[string]string) {
+	ctx := t.Context()
 	for k, v := range testcases {
 		dsk := ds.NewKey(k)
-		if err := d.Put(context.Background(), dsk, []byte(v)); err != nil {
+		if err := d.Put(ctx, dsk, []byte(v)); err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	for k, v := range testcases {
 		dsk := ds.NewKey(k)
-		v2, err := d.Get(context.Background(), dsk)
+		v2, err := d.Get(ctx, dsk)
 		if err != nil {
 			t.Fatal(err)
 		}
-		v2b := v2
-		if string(v2b) != v {
+		if string(v2) != v {
 			t.Errorf("%s values differ: %s != %s", k, v, v2)
 		}
 	}
@@ -145,9 +145,10 @@ func TestQuery(t *testing.T) {
 	defer done()
 
 	addTestCases(t, d, testcases)
+	ctx := t.Context()
 
 	// test prefix
-	rs, err := d.Query(context.Background(), dsq.Query{Prefix: "/a/"})
+	rs, err := d.Query(ctx, dsq.Query{Prefix: "/a/"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +161,7 @@ func TestQuery(t *testing.T) {
 	}, rs)
 
 	// test offset and limit
-	rs, err = d.Query(context.Background(), dsq.Query{Prefix: "/a/", Offset: 2, Limit: 2})
+	rs, err = d.Query(ctx, dsq.Query{Prefix: "/a/", Offset: 2, Limit: 2})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +173,7 @@ func TestQuery(t *testing.T) {
 	// test orders
 	orbk := dsq.OrderByKey{}
 	orderByKey := []dsq.Order{orbk}
-	rs, err = d.Query(context.Background(), dsq.Query{Prefix: "/a/", Orders: orderByKey})
+	rs, err = d.Query(ctx, dsq.Query{Prefix: "/a/", Orders: orderByKey})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +187,7 @@ func TestQuery(t *testing.T) {
 
 	orbkd := dsq.OrderByKeyDescending{}
 	orderByDesc := []dsq.Order{orbkd}
-	rs, err = d.Query(context.Background(), dsq.Query{Prefix: "/a/", Orders: orderByDesc})
+	rs, err = d.Query(ctx, dsq.Query{Prefix: "/a/", Orders: orderByDesc})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +202,7 @@ func TestQuery(t *testing.T) {
 	// test filters
 	equalFilter := dsq.FilterKeyCompare{Op: dsq.Equal, Key: "/a/b"}
 	equalFilters := []dsq.Filter{equalFilter}
-	rs, err = d.Query(context.Background(), dsq.Query{Prefix: "/a/", Filters: equalFilters})
+	rs, err = d.Query(ctx, dsq.Query{Prefix: "/a/", Filters: equalFilters})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +210,7 @@ func TestQuery(t *testing.T) {
 
 	greaterThanFilter := dsq.FilterKeyCompare{Op: dsq.GreaterThan, Key: "/a/b"}
 	greaterThanFilters := []dsq.Filter{greaterThanFilter}
-	rs, err = d.Query(context.Background(), dsq.Query{Prefix: "/a/", Filters: greaterThanFilters})
+	rs, err = d.Query(ctx, dsq.Query{Prefix: "/a/", Filters: greaterThanFilters})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,7 +223,7 @@ func TestQuery(t *testing.T) {
 
 	lessThanFilter := dsq.FilterKeyCompare{Op: dsq.LessThanOrEqual, Key: "/a/b/c"}
 	lessThanFilters := []dsq.Filter{lessThanFilter}
-	rs, err = d.Query(context.Background(), dsq.Query{Prefix: "/a/", Filters: lessThanFilters})
+	rs, err = d.Query(ctx, dsq.Query{Prefix: "/a/", Filters: lessThanFilters})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -236,8 +237,9 @@ func TestHas(t *testing.T) {
 	d, done := newDS(t)
 	defer done()
 	addTestCases(t, d, testcases)
+	ctx := t.Context()
 
-	has, err := d.Has(context.Background(), ds.NewKey("/a/b/c"))
+	has, err := d.Has(ctx, ds.NewKey("/a/b/c"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -246,7 +248,7 @@ func TestHas(t *testing.T) {
 		t.Error("Key should be found")
 	}
 
-	has, err = d.Has(context.Background(), ds.NewKey("/a/b/c/d"))
+	has, err = d.Has(ctx, ds.NewKey("/a/b/c/d"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -260,8 +262,9 @@ func TestNotExistGet(t *testing.T) {
 	d, done := newDS(t)
 	defer done()
 	addTestCases(t, d, testcases)
+	ctx := t.Context()
 
-	has, err := d.Has(context.Background(), ds.NewKey("/a/b/c/d"))
+	has, err := d.Has(ctx, ds.NewKey("/a/b/c/d"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -270,7 +273,7 @@ func TestNotExistGet(t *testing.T) {
 		t.Error("Key should not be found")
 	}
 
-	val, err := d.Get(context.Background(), ds.NewKey("/a/b/c/d"))
+	val, err := d.Get(ctx, ds.NewKey("/a/b/c/d"))
 	if val != nil {
 		t.Error("Key should not be found")
 	}
@@ -287,8 +290,9 @@ func TestDelete(t *testing.T) {
 	d, done := newDS(t)
 	defer done()
 	addTestCases(t, d, testcases)
+	ctx := t.Context()
 
-	has, err := d.Has(context.Background(), ds.NewKey("/a/b/c"))
+	has, err := d.Has(ctx, ds.NewKey("/a/b/c"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -296,12 +300,12 @@ func TestDelete(t *testing.T) {
 		t.Error("Key should be found")
 	}
 
-	err = d.Delete(context.Background(), ds.NewKey("/a/b/c"))
+	err = d.Delete(ctx, ds.NewKey("/a/b/c"))
 	if err != nil {
 		t.Error(err)
 	}
 
-	has, err = d.Has(context.Background(), ds.NewKey("/a/b/c"))
+	has, err = d.Has(ctx, ds.NewKey("/a/b/c"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -313,13 +317,14 @@ func TestDelete(t *testing.T) {
 func TestGetEmpty(t *testing.T) {
 	d, done := newDS(t)
 	defer done()
+	ctx := t.Context()
 
-	err := d.Put(context.Background(), ds.NewKey("/a"), []byte{})
+	err := d.Put(ctx, ds.NewKey("/a"), []byte{})
 	if err != nil {
 		t.Error(err)
 	}
 
-	v, err := d.Get(context.Background(), ds.NewKey("/a"))
+	v, err := d.Get(ctx, ds.NewKey("/a"))
 	if err != nil {
 		t.Error(err)
 	}
@@ -332,26 +337,27 @@ func TestGetEmpty(t *testing.T) {
 func TestBatching(t *testing.T) {
 	d, done := newDS(t)
 	defer done()
+	ctx := t.Context()
 
-	b, err := d.Batch(context.Background())
+	b, err := d.Batch(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for k, v := range testcases {
-		err := b.Put(context.Background(), ds.NewKey(k), []byte(v))
+		err := b.Put(ctx, ds.NewKey(k), []byte(v))
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	err = b.Commit(context.Background())
+	err = b.Commit(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for k, v := range testcases {
-		val, err := d.Get(context.Background(), ds.NewKey(k))
+		val, err := d.Get(ctx, ds.NewKey(k))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -362,27 +368,27 @@ func TestBatching(t *testing.T) {
 	}
 
 	//Test delete
-	b, err = d.Batch(context.Background())
+	b, err = d.Batch(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = b.Delete(context.Background(), ds.NewKey("/a/b"))
+	err = b.Delete(ctx, ds.NewKey("/a/b"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = b.Delete(context.Background(), ds.NewKey("/a/b/c"))
+	err = b.Delete(ctx, ds.NewKey("/a/b/c"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = b.Commit(context.Background())
+	err = b.Commit(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	rs, err := d.Query(context.Background(), dsq.Query{Prefix: "/"})
+	rs, err := d.Query(ctx, dsq.Query{Prefix: "/"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,16 +407,17 @@ func TestBatching(t *testing.T) {
 func SubtestBasicPutGet(t *testing.T) {
 	d, done := newDS(t)
 	defer done()
+	ctx := t.Context()
 
 	k := ds.NewKey("foo")
 	val := []byte("Hello Datastore!")
 
-	err := d.Put(context.Background(), k, val)
+	err := d.Put(ctx, k, val)
 	if err != nil {
 		t.Fatal("error putting to datastore: ", err)
 	}
 
-	have, err := d.Has(context.Background(), k)
+	have, err := d.Has(ctx, k)
 	if err != nil {
 		t.Fatal("error calling has on key we just put: ", err)
 	}
@@ -419,7 +426,7 @@ func SubtestBasicPutGet(t *testing.T) {
 		t.Fatal("should have key foo, has returned false")
 	}
 
-	size, err := d.GetSize(context.Background(), k)
+	size, err := d.GetSize(ctx, k)
 	if err != nil {
 		t.Fatal("error getting size after put: ", err)
 	}
@@ -427,7 +434,7 @@ func SubtestBasicPutGet(t *testing.T) {
 		t.Fatalf("incorrect size: expected %d, got %d", len(val), size)
 	}
 
-	out, err := d.Get(context.Background(), k)
+	out, err := d.Get(ctx, k)
 	if err != nil {
 		t.Fatal("error getting value after put: ", err)
 	}
@@ -436,7 +443,7 @@ func SubtestBasicPutGet(t *testing.T) {
 		t.Fatal("value received on get wasnt what we expected:", out)
 	}
 
-	have, err = d.Has(context.Background(), k)
+	have, err = d.Has(ctx, k)
 	if err != nil {
 		t.Fatal("error calling has after get: ", err)
 	}
@@ -445,7 +452,7 @@ func SubtestBasicPutGet(t *testing.T) {
 		t.Fatal("should have key foo, has returned false")
 	}
 
-	size, err = d.GetSize(context.Background(), k)
+	size, err = d.GetSize(ctx, k)
 	if err != nil {
 		t.Fatal("error getting size after get: ", err)
 	}
@@ -453,12 +460,12 @@ func SubtestBasicPutGet(t *testing.T) {
 		t.Fatalf("incorrect size: expected %d, got %d", len(val), size)
 	}
 
-	err = d.Delete(context.Background(), k)
+	err = d.Delete(ctx, k)
 	if err != nil {
 		t.Fatal("error calling delete: ", err)
 	}
 
-	have, err = d.Has(context.Background(), k)
+	have, err = d.Has(ctx, k)
 	if err != nil {
 		t.Fatal("error calling has after delete: ", err)
 	}
@@ -467,12 +474,11 @@ func SubtestBasicPutGet(t *testing.T) {
 		t.Fatal("should not have key foo, has returned true")
 	}
 
-	size, err = d.GetSize(context.Background(), k)
-	switch err {
-	case ds.ErrNotFound:
-	case nil:
+	size, err = d.GetSize(ctx, k)
+	if err == nil {
 		t.Fatal("expected error getting size after delete")
-	default:
+	}
+	if !errors.Is(err, ds.ErrNotFound) {
 		t.Fatal("wrong error getting size after delete: ", err)
 	}
 	if size != -1 {
@@ -483,10 +489,11 @@ func SubtestBasicPutGet(t *testing.T) {
 func TestNotFounds(t *testing.T) {
 	d, done := newDS(t)
 	defer done()
+	ctx := t.Context()
 
 	badk := ds.NewKey("notreal")
 
-	val, err := d.Get(context.Background(), badk)
+	val, err := d.Get(ctx, badk)
 	if err != ds.ErrNotFound {
 		t.Fatal("expected ErrNotFound for key that doesnt exist, got: ", err)
 	}
@@ -495,7 +502,7 @@ func TestNotFounds(t *testing.T) {
 		t.Fatal("get should always return nil for not found values")
 	}
 
-	have, err := d.Has(context.Background(), badk)
+	have, err := d.Has(ctx, badk)
 	if err != nil {
 		t.Fatal("error calling has on not found key: ", err)
 	}
@@ -503,12 +510,11 @@ func TestNotFounds(t *testing.T) {
 		t.Fatal("has returned true for key we don't have")
 	}
 
-	size, err := d.GetSize(context.Background(), badk)
-	switch err {
-	case ds.ErrNotFound:
-	case nil:
+	size, err := d.GetSize(ctx, badk)
+	if err == nil {
 		t.Fatal("expected error getting size after delete")
-	default:
+	}
+	if !errors.Is(err, ds.ErrNotFound) {
 		t.Fatal("wrong error getting size after delete: ", err)
 	}
 	if size != -1 {
@@ -534,9 +540,11 @@ func SubtestManyKeysAndQuery(t *testing.T) {
 		values = append(values, buf)
 	}
 
+	ctx := t.Context()
+
 	t.Logf("putting %d values", count)
 	for i, k := range keys {
-		err := d.Put(context.Background(), k, values[i])
+		err := d.Put(ctx, k, values[i])
 		if err != nil {
 			t.Fatalf("error on put[%d]: %s", i, err)
 		}
@@ -544,7 +552,7 @@ func SubtestManyKeysAndQuery(t *testing.T) {
 
 	t.Log("getting values back")
 	for i, k := range keys {
-		val, err := d.Get(context.Background(), k)
+		val, err := d.Get(ctx, k)
 		if err != nil {
 			t.Fatalf("error on get[%d]: %s", i, err)
 		}
@@ -556,7 +564,7 @@ func SubtestManyKeysAndQuery(t *testing.T) {
 
 	t.Log("querying values")
 	q := dsq.Query{KeysOnly: true}
-	resp, err := d.Query(context.Background(), q)
+	resp, err := d.Query(ctx, q)
 	if err != nil {
 		t.Fatal("calling query: ", err)
 	}
@@ -576,8 +584,8 @@ func SubtestManyKeysAndQuery(t *testing.T) {
 	}
 
 	t.Log("verifying query output")
-	sort.Strings(keystrs)
-	sort.Strings(outkeys)
+	slices.Sort(keystrs)
+	slices.Sort(outkeys)
 
 	if len(keystrs) != len(outkeys) {
 		t.Fatal("got wrong number of keys back")
@@ -591,7 +599,7 @@ func SubtestManyKeysAndQuery(t *testing.T) {
 
 	t.Log("deleting all keys")
 	for _, k := range keys {
-		if err := d.Delete(context.Background(), k); err != nil {
+		if err := d.Delete(ctx, k); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -601,16 +609,17 @@ func SubtestManyKeysAndQuery(t *testing.T) {
 func TestBasicPutGet(t *testing.T) {
 	d, done := newDS(t)
 	defer done()
+	ctx := t.Context()
 
 	k := ds.NewKey("foo")
 	val := []byte("Hello Datastore!")
 
-	err := d.Put(context.Background(), k, val)
+	err := d.Put(ctx, k, val)
 	if err != nil {
 		t.Fatal("error putting to datastore: ", err)
 	}
 
-	have, err := d.Has(context.Background(), k)
+	have, err := d.Has(ctx, k)
 	if err != nil {
 		t.Fatal("error calling has on key we just put: ", err)
 	}
@@ -619,7 +628,7 @@ func TestBasicPutGet(t *testing.T) {
 		t.Fatal("should have key foo, has returned false")
 	}
 
-	out, err := d.Get(context.Background(), k)
+	out, err := d.Get(ctx, k)
 	if err != nil {
 		t.Fatal("error getting value after put: ", err)
 	}
@@ -628,7 +637,7 @@ func TestBasicPutGet(t *testing.T) {
 		t.Fatal("value received on get wasnt what we expected:", out)
 	}
 
-	have, err = d.Has(context.Background(), k)
+	have, err = d.Has(ctx, k)
 	if err != nil {
 		t.Fatal("error calling has after get: ", err)
 	}
@@ -637,12 +646,12 @@ func TestBasicPutGet(t *testing.T) {
 		t.Fatal("should have key foo, has returned false")
 	}
 
-	err = d.Delete(context.Background(), k)
+	err = d.Delete(ctx, k)
 	if err != nil {
 		t.Fatal("error calling delete: ", err)
 	}
 
-	have, err = d.Has(context.Background(), k)
+	have, err = d.Has(ctx, k)
 	if err != nil {
 		t.Fatal("error calling has after delete: ", err)
 	}
@@ -671,9 +680,11 @@ func TestManyKeysAndQuery(t *testing.T) {
 		values = append(values, buf)
 	}
 
+	ctx := t.Context()
+
 	t.Logf("putting %d values", count)
 	for i, k := range keys {
-		err := d.Put(context.Background(), k, values[i])
+		err := d.Put(ctx, k, values[i])
 		if err != nil {
 			t.Fatalf("error on put[%d]: %s", i, err)
 		}
@@ -681,7 +692,7 @@ func TestManyKeysAndQuery(t *testing.T) {
 
 	t.Log("getting values back")
 	for i, k := range keys {
-		val, err := d.Get(context.Background(), k)
+		val, err := d.Get(ctx, k)
 		if err != nil {
 			t.Fatalf("error on get[%d]: %s", i, err)
 		}
@@ -693,7 +704,7 @@ func TestManyKeysAndQuery(t *testing.T) {
 
 	t.Log("querying values")
 	q := dsq.Query{KeysOnly: true}
-	resp, err := d.Query(context.Background(), q)
+	resp, err := d.Query(ctx, q)
 	if err != nil {
 		t.Fatal("calling query: ", err)
 	}
@@ -713,8 +724,8 @@ func TestManyKeysAndQuery(t *testing.T) {
 	}
 
 	t.Log("verifying query output")
-	sort.Strings(keystrs)
-	sort.Strings(outkeys)
+	slices.Sort(keystrs)
+	slices.Sort(outkeys)
 
 	if len(keystrs) != len(outkeys) {
 		t.Fatalf("got wrong number of keys back, %d != %d", len(keystrs), len(outkeys))
@@ -728,7 +739,7 @@ func TestManyKeysAndQuery(t *testing.T) {
 
 	t.Log("deleting all keys")
 	for _, k := range keys {
-		if err := d.Delete(context.Background(), k); err != nil {
+		if err := d.Delete(ctx, k); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -758,6 +769,7 @@ func expectMatches(t *testing.T, expect []string, actualR dsq.Results) {
 		for _, e := range actual {
 			if e.Key == k {
 				found = true
+				break
 			}
 		}
 		if !found {

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/ipfs/go-ds-sql
 
-go 1.25
+go 1.25.0
 
 require (
-	github.com/ipfs/go-datastore v0.9.1
+	github.com/ipfs/go-datastore v0.9.2
 	github.com/lib/pq v1.12.3
 	github.com/mattn/go-sqlite3 v1.14.47
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/ipfs/go-datastore v0.9.1 h1:67Po2epre/o0UxrmkzdS9ZTe2GFGODgTd2odx8Wh6Yo=
-github.com/ipfs/go-datastore v0.9.1/go.mod h1:zi07Nvrpq1bQwSkEnx3bfjz+SQZbdbWyCNvyxMh9pN0=
+github.com/ipfs/go-datastore v0.9.2 h1:HJOgAmvWPRMHiwD8JHBzGZQNTKhuFGYfp8bNPwye28g=
+github.com/ipfs/go-datastore v0.9.2/go.mod h1:VIjDxnINIcCqBMaB8LGggHfYY7PalKWfPtRMFeOU4q4=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
 github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46UU0LZ723meps=
 github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=

--- a/txn.go
+++ b/txn.go
@@ -3,6 +3,7 @@ package sqlds
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 
 	datastore "github.com/ipfs/go-datastore"
@@ -41,42 +42,42 @@ func (t *txn) Get(ctx context.Context, key datastore.Key) ([]byte, error) {
 	row := t.txn.QueryRowContext(ctx, t.queries.Get(), key.String())
 	var out []byte
 
-	switch err := row.Scan(&out); err {
-	case sql.ErrNoRows:
-		return nil, datastore.ErrNotFound
-	case nil:
-		return out, nil
-	default:
+	err := row.Scan(&out)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, datastore.ErrNotFound
+		}
 		return nil, err
 	}
+	return out, nil
 }
 
 func (t *txn) Has(ctx context.Context, key datastore.Key) (bool, error) {
 	row := t.txn.QueryRowContext(ctx, t.queries.Exists(), key.String())
 	var exists bool
 
-	switch err := row.Scan(&exists); err {
-	case sql.ErrNoRows:
-		return exists, nil
-	case nil:
-		return exists, nil
-	default:
+	err := row.Scan(&exists)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return exists, nil
+		}
 		return exists, err
 	}
+	return exists, nil
 }
 
 func (t *txn) GetSize(ctx context.Context, key datastore.Key) (int, error) {
 	row := t.txn.QueryRowContext(ctx, t.queries.GetSize(), key.String())
 	var size int
 
-	switch err := row.Scan(&size); err {
-	case sql.ErrNoRows:
-		return -1, datastore.ErrNotFound
-	case nil:
-		return size, nil
-	default:
+	err := row.Scan(&size)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return -1, datastore.ErrNotFound
+		}
 		return 0, err
 	}
+	return size, nil
 }
 
 func (t *txn) Query(ctx context.Context, q dsq.Query) (dsq.Results, error) {


### PR DESCRIPTION
- Use errors.Is
- Use t.Context() instead of context.Background()
- update go-datastore to v0.9.2